### PR TITLE
Use font ascent to define upper right of character bounding box

### DIFF
--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -302,9 +302,10 @@ class LTChar(LTComponent, LTText):
             bbox_upper_right = (-vx + fontsize, vy + rise)
         else:
             # horizontal
+            ascent = font.get_ascent() * fontsize
             descent = font.get_descent() * fontsize
             bbox_lower_left = (0, descent + rise)
-            bbox_upper_right = (self.adv, descent + rise + fontsize)
+            bbox_upper_right = (self.adv, ascent + rise)
         (a, b, c, d, e, f) = self.matrix
         self.upright = (0 < a*d*scaling and b*c <= 0)
         (x0, y0) = apply_matrix_pt(self.matrix, bbox_lower_left)


### PR DESCRIPTION
I don't have reason to believe this is the "right" way of doing things but it does appear to work well on our current test PDFs and better on the new Chinese documents.