### PR TITLE
Specify char box coordinates

### DIFF
--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -118,8 +118,9 @@ class PDFLayoutAnalyzer(PDFTextDevice):
             text = self.handle_undefined_char(font, cid)
         textwidth = font.char_width(cid)
         textdisp = font.char_disp(cid)
+        glyph_bbox = font.get_bbox(cid)
         item = LTChar(matrix, font, fontsize, scaling, rise, text, textwidth,
-                      textdisp, ncs, graphicstate)
+                      textdisp, ncs, graphicstate, glyph_bbox)
         self.cur_item.add(item)
         return item.adv
 

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -307,6 +307,7 @@ class LTChar(LTComponent, LTText):
                 bbox_lower_left = (glyph_bbox[0] / 1000, glyph_bbox[1] / 1000)
                 bbox_upper_right = (glyph_bbox[2] / 1000, glyph_bbox[3] / 1000)
             else:
+                # Using the default font level info embedded in the PDF
                 ascent = font.get_ascent() * fontsize
                 descent = font.get_descent() * fontsize
                 bbox_lower_left = (0, descent + rise)

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -281,7 +281,7 @@ class LTChar(LTComponent, LTText):
     """Actual letter in the text as a Unicode string."""
 
     def __init__(self, matrix, font, fontsize, scaling, rise,
-                 text, textwidth, textdisp, ncs, graphicstate):
+                 text, textwidth, textdisp, ncs, graphicstate, glyph_bbox):
         LTText.__init__(self)
         self._text = text
         self.matrix = matrix
@@ -302,10 +302,15 @@ class LTChar(LTComponent, LTText):
             bbox_upper_right = (-vx + fontsize, vy + rise)
         else:
             # horizontal
-            ascent = font.get_ascent() * fontsize
-            descent = font.get_descent() * fontsize
-            bbox_lower_left = (0, descent + rise)
-            bbox_upper_right = (self.adv, ascent + rise)
+            if glyph_bbox is not None:
+                # If available, use glyph bounding box
+                bbox_lower_left = (glyph_bbox[0] / 1000, glyph_bbox[1] / 1000)
+                bbox_upper_right = (glyph_bbox[2] / 1000, glyph_bbox[3] / 1000)
+            else:
+                ascent = font.get_ascent() * fontsize
+                descent = font.get_descent() * fontsize
+                bbox_lower_left = (0, descent + rise)
+                bbox_upper_right = (self.adv, ascent + rise)
         (a, b, c, d, e, f) = self.matrix
         self.upright = (0 < a*d*scaling and b*c <= 0)
         (x0, y0) = apply_matrix_pt(self.matrix, bbox_lower_left)

--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -488,7 +488,7 @@ LITERAL_TYPE1C = LIT('Type1C')
 
 class PDFFont:
 
-    def __init__(self, descriptor, widths, default_width=None):
+    def __init__(self, descriptor, widths, default_width=None, glyph_boxes=None):
         self.descriptor = descriptor
         self.widths = resolve_all(widths)
         self.fontname = resolve1(descriptor.get('FontName', 'unknown'))
@@ -506,6 +506,7 @@ class PDFFont:
         self.bbox = list_value(resolve_all(descriptor.get('FontBBox',
                                                           (0, 0, 0, 0))))
         self.hscale = self.vscale = .001
+        self.glyph_boxes = glyph_boxes
 
         # PDF RM 9.8.1 specifies /Descent should always be a negative number.
         # PScript5.dll seems to produce Descent with a positive number, but
@@ -540,6 +541,11 @@ class PDFFont:
         if w == 0:
             w = -self.default_width
         return w * self.hscale
+
+    def get_bbox(self, cid):
+      if self.glyph_boxes is not None:
+        if cid in self.glyph_boxes:
+          return self.glyph_boxes[cid]
 
     def get_height(self):
         h = self.bbox[3]-self.bbox[1]

--- a/pdfminer/pdffont.py
+++ b/pdfminer/pdffont.py
@@ -544,10 +544,16 @@ class PDFFont:
         return w * self.hscale
 
     def get_bbox(self, cid: int) -> Optional[Tuple[float, float, float, float]]:
+      """ Get glyph bounding box
+      :param cid: cid (character identifier) which points to a font character and glyph
+      :return: returns bounding box if glyph bounding boxes are provided and cid has a
+        corresponding glyph, otherwise returns None
+      """
       if self.glyph_bounding_box is not None:
         cid = str(cid)
         if cid in self.glyph_bounding_box:
           return self.glyph_bounding_box[cid]
+        return
       return self.font_bounding_box
 
     def get_height(self):

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -1,6 +1,8 @@
 import re
 import logging
 from io import BytesIO
+from typing import Optional, Dict, Tuple
+
 from .cmapdb import CMapDB
 from .cmapdb import CMap
 from .psparser import PSTypeError
@@ -141,10 +143,12 @@ class PDFResourceManager:
     allocated multiple times.
     """
 
-    def __init__(self, caching=True):
+    def __init__(self, caching: bool = True,
+                 glyph_boxes_per_font: Optional[
+                     Dict[str, Dict[int, Tuple[float, float, float, float]]]] = None):
         self.caching = caching
         self._cached_fonts = {}
-        return
+        self.glyph_boxes_per_font = glyph_boxes_per_font
 
     def get_procset(self, procs):
         for proc in procs:
@@ -204,6 +208,10 @@ class PDFResourceManager:
                 if settings.STRICT:
                     raise PDFFontError('Invalid Font spec: %r' % spec)
                 font = PDFType1Font(self, spec)  # this is so wrong!
+            if objid and self.glyph_boxes_per_font is not None:
+                # If available, set glyph boxes for each font
+                if font.fontname in self.glyph_boxes_per_font:
+                    font.glyph_boxes = self.glyph_boxes_per_font[font.fontname]
             if objid and self.caching:
                 self._cached_fonts[objid] = font
         return font

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -213,7 +213,7 @@ class PDFResourceManager:
                     raise PDFFontError('Invalid Font spec: %r' % spec)
                 font = PDFType1Font(self, spec)  # this is so wrong!
             if objid and self.bbox_per_font_and_glyph is not None:
-                # If available, set glyph boxes for each font
+                # If available, set custom glyph boxes for each font
                 if font.fontname in self.bbox_per_font_and_glyph:
                     font.glyph_bounding_box = self.bbox_per_font_and_glyph[font.fontname]
             if objid and self.bbox_per_font is not None:

--- a/pdfminer/pdfinterp.py
+++ b/pdfminer/pdfinterp.py
@@ -144,11 +144,15 @@ class PDFResourceManager:
     """
 
     def __init__(self, caching: bool = True,
-                 glyph_boxes_per_font: Optional[
-                     Dict[str, Dict[int, Tuple[float, float, float, float]]]] = None):
+                 bbox_per_font_and_glyph: Optional[
+                     Dict[str, Dict[str, Tuple[float, float, float, float]]]] = None,
+                 bbox_per_font: Optional[
+                     Dict[str, Tuple[float, float, float, float]]] = None
+                 ):
         self.caching = caching
         self._cached_fonts = {}
-        self.glyph_boxes_per_font = glyph_boxes_per_font
+        self.bbox_per_font_and_glyph = bbox_per_font_and_glyph
+        self.bbox_per_font = bbox_per_font
 
     def get_procset(self, procs):
         for proc in procs:
@@ -208,10 +212,14 @@ class PDFResourceManager:
                 if settings.STRICT:
                     raise PDFFontError('Invalid Font spec: %r' % spec)
                 font = PDFType1Font(self, spec)  # this is so wrong!
-            if objid and self.glyph_boxes_per_font is not None:
+            if objid and self.bbox_per_font_and_glyph is not None:
                 # If available, set glyph boxes for each font
-                if font.fontname in self.glyph_boxes_per_font:
-                    font.glyph_boxes = self.glyph_boxes_per_font[font.fontname]
+                if font.fontname in self.bbox_per_font_and_glyph:
+                    font.glyph_bounding_box = self.bbox_per_font_and_glyph[font.fontname]
+            if objid and self.bbox_per_font is not None:
+                # If available, set a minimal bounding box that bounds all glyph boxes for each font
+                if font.fontname in self.bbox_per_font:
+                    font.font_bounding_box = self.bbox_per_font[font.fontname]
             if objid and self.caching:
                 self._cached_fonts[objid] = font
         return font


### PR DESCRIPTION
Allow user to specify 2 more options:
1. Bounding box provided for each glyph for each font.
2. Bounding box provided for each font. That bounding box contains all glyphs in that font.

Related to https://github.com/vannevar-labs/arnold/pull/786